### PR TITLE
Replace "py_modules" with "packages" to enable installation via pip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+/.idea/

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ setup(
     author='Bryan Veloso',
     author_email='bryan@revyver.com',
     url='https://github.com/bryanveloso/geopatterns',
-    # py_modules=['geopatterns'],
     packages=setuptools.find_packages(
         exclude=[
             'tests',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,13 @@ setup(
     author='Bryan Veloso',
     author_email='bryan@revyver.com',
     url='https://github.com/bryanveloso/geopatterns',
-    py_modules=['geopatterns'],
+    # py_modules=['geopatterns'],
+    packages=setuptools.find_packages(
+        exclude=[
+            'tests',
+            'tests.*',
+        ],
+    ),
     install_requires=['colour'],
     license='MIT',
 )


### PR DESCRIPTION
I am currently unable to install `geopatterns` from `master` branch of the main repo. The installation works, but `geopatterns` directory does not appear in `site-packages`.

Python: 3.9.2
pip: 21.0.1

After the change proposed in this PR, installation with pip from Github works.